### PR TITLE
Run scans via start_scan in separate process

### DIFF
--- a/scan_manager.py
+++ b/scan_manager.py
@@ -1,8 +1,8 @@
-from multiprocessing import Process, Manager
+from multiprocessing import Process
 
-# Global manager for scan processes (by scanner type)
-manager = Manager()
-scan_registry = manager.dict()
+# Registry of active scan processes by scanner type. A normal dictionary is
+# sufficient since only the main application process interacts with it.
+scan_registry = {}
 
 def start_scan(scanner_type, func, *args):
     # Kill any previous scan


### PR DESCRIPTION
## Summary
- Replace thread-based scan execution with `start_scan` to run scanners in separate processes
- Share scan results through a multiprocessing Manager for cross-process updates
- Simplify process tracking in `scan_manager` using a standard dictionary

## Testing
- `python -m py_compile app.py scan_manager.py`
- `pytest -q`
- `python - <<'PY'
from scan_manager import start_scan, stop_scan
import time
proc = start_scan('test', time.sleep, 10)
print('proc started', proc.is_alive())
print('stop', stop_scan('test'))
print('proc alive after', proc.is_alive())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68acb0ad90448329aee36a12f8eb1f65